### PR TITLE
CDRIVER-613 remove GCC-specific min/max macros.

### DIFF
--- a/src/bson/bson-macros.h
+++ b/src/bson/bson-macros.h
@@ -82,12 +82,6 @@
 #  define BSON_MIN(a, b) ( (std::min)(a, b) )
 #elif defined(_MSC_VER)
 #  define BSON_MIN(a, b) ((a) < (b) ? (a) : (b))
-#elif defined(__GNUC__)
-#  define BSON_MIN(a, b) ({     \
-                        __typeof__ (a)_a = (a); \
-                        __typeof__ (b)_b = (b); \
-                        _a < _b ? _a : _b;   \
-                     })
 #else
 #  define BSON_MIN(a,b) (((a) < (b)) ? (a) : (b))
 #endif
@@ -99,12 +93,6 @@
 #  define BSON_MAX(a, b) ( (std::max)(a, b) )
 #elif defined(_MSC_VER)
 #  define BSON_MAX(a, b) ((a) > (b) ? (a) : (b))
-#elif defined(__GNUC__)
-#  define BSON_MAX(a, b) ({     \
-                        __typeof__ (a)_a = (a); \
-                        __typeof__ (b)_b = (b); \
-                        _a > _b ? _a : _b;   \
-                     })
 #else
 #  define BSON_MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif


### PR DESCRIPTION
CDRIVER-613 remove GCC-specific min/max macros.

If deleting the specialized macros breaks anything, that means something's already broken on a platform that doesn't use the specialized macros. If deleting them doesn't break anything, then we didn't need them in the first place.
